### PR TITLE
Remove extra curly brace from example nginx config

### DIFF
--- a/pages/how-to-guides/collect-nginx-logs.mdx
+++ b/pages/how-to-guides/collect-nginx-logs.mdx
@@ -30,7 +30,6 @@ received from the UI in the step above.
     "nginx-logs": {
         "type": "nginx_syslog",
         "addr": "127.0.0.1:5514",
-      },
     },
   },
   "destinations": {


### PR DESCRIPTION
Just fixing a small typo in the nginx example