### PR TITLE
Update redirects for moved AI Chat reference pages

### DIFF
--- a/out/_redirects
+++ b/out/_redirects
@@ -1,0 +1,7 @@
+# Redirects for moved AI Chat pages
+/reference/native-ai-chat /ai-chat/native-ai-chat 301
+/reference/model-context-protocol /ai-chat/model-context-protocol 301
+/reference/custom-prompts /ai-chat/custom-prompts 301
+/references/native-ai-chat /ai-chat/native-ai-chat 301
+
+


### PR DESCRIPTION
Introduces a _redirects file to handle 301 redirects from old AI Chat reference URLs to their new locations under /ai-chat. This ensures users and search engines are directed to the updated pages. adds redirects to out/ folder that cf pages expexts.
https://developers.cloudflare.com/pages/configuration/redirects/