### PR TITLE
Add Copy Text Button for pasting into genai

### DIFF
--- a/components/CopyPageButton.tsx
+++ b/components/CopyPageButton.tsx
@@ -1,0 +1,288 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+export function CopyPageButton() {
+  const [copied, setCopied] = useState(false)
+  const [isMobile, setIsMobile] = useState(false)
+  const [buttonPosition, setButtonPosition] = useState({ top: 20, left: 0 })
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const checkMobile = () => setIsMobile(window.innerWidth < 768)
+    checkMobile()
+    window.addEventListener('resize', checkMobile)
+    return () => window.removeEventListener('resize', checkMobile)
+  }, [])
+
+  // Calculate position relative to article and update on scroll
+  useEffect(() => {
+    const updatePosition = () => {
+      const article = document.querySelector('article, .nextra-content, main[role="main"], .prose')
+      if (!article) return
+
+      const rect = article.getBoundingClientRect()
+      const scrollTop = window.pageYOffset || document.documentElement.scrollTop
+      
+      // Calculate position relative to article, moving with the page
+      setButtonPosition({
+        top: rect.top + scrollTop + 20, // 20px from top of article
+        left: rect.left + rect.width - 120 // 120px from right edge of article
+      })
+      
+      setIsVisible(true)
+    }
+
+    // Update position on scroll and resize
+    const handleScroll = () => {
+      updatePosition()
+    }
+
+    const handleResize = () => {
+      updatePosition()
+    }
+
+    const timer = setTimeout(updatePosition, 100)
+    window.addEventListener('scroll', handleScroll)
+    window.addEventListener('resize', handleResize)
+
+    return () => {
+      clearTimeout(timer)
+      window.removeEventListener('scroll', handleScroll)
+      window.removeEventListener('resize', handleResize)
+    }
+  }, [])
+
+  const copyPageContent = async () => {
+    try {
+      // Find the main article content
+      const article = document.querySelector('article, .nextra-content, main[role="main"], .prose')
+      
+      if (!article) {
+        console.error('No article content found')
+        return
+      }
+
+      // Clone to avoid modifying DOM
+      const clone = article.cloneNode(true) as HTMLElement
+      
+      // Remove unwanted elements more aggressively
+      const removeSelectors = [
+        'nav', 
+        'aside', 
+        'button', 
+        '.nextra-toc', 
+        '.nextra-breadcrumb',
+        '.nextra-breadcrumb-container',
+        '.nextra-footer',
+        '.nextra-footer-container',
+        '.nextra-nav',
+        '.nextra-sidebar',
+        '.nextra-sidebar-container',
+        '.nextra-theme-toggle',
+        '.nextra-toc-footer',
+        '.nextra-toc-container',
+        '[role="navigation"]',
+        '[role="complementary"]',
+        '.theme-toggle',
+        '.sidebar',
+        '.navigation',
+        '.footer',
+        '.breadcrumb',
+        '.toc',
+        '.toc-container',
+        '.sidebar-container',
+        '.nav-container',
+        '.footer-container'
+      ]
+      removeSelectors.forEach(selector => {
+        clone.querySelectorAll(selector).forEach(el => el.remove())
+      })
+
+      // Remove specific text content that we don't want
+      const removeTextContent = (element: HTMLElement) => {
+        const walker = document.createTreeWalker(
+          element,
+          NodeFilter.SHOW_TEXT,
+          null
+        )
+
+        const textNodes: Text[] = []
+        let node
+        while (node = walker.nextNode()) {
+          textNodes.push(node as Text)
+        }
+
+        textNodes.forEach(textNode => {
+          const text = textNode.textContent || ''
+          const parent = textNode.parentElement
+
+          // Remove "Last updated on" text
+          if (text.includes('Last updated on') || text.includes('last updated')) {
+            if (parent) {
+              parent.remove()
+            }
+          }
+
+          // Remove "How To Guides" text
+          if (text.includes('How To Guides')) {
+            if (parent) {
+              parent.remove()
+            }
+          }
+
+          // Remove Previous/Next navigation text
+          if (text.includes('Previous') || text.includes('Next') || text.includes('←') || text.includes('→')) {
+            if (parent && (parent.tagName === 'A' || parent.closest('a'))) {
+              parent.remove()
+            }
+          }
+
+          // Remove "Next Steps" section if it contains navigation links
+          if (text.includes('Next Steps') && parent) {
+            const nextStepsSection = parent.closest('section, div, h2, h3')
+            if (nextStepsSection) {
+              // Check if this section contains navigation links
+              const hasNavLinks = nextStepsSection.querySelectorAll('a[href*="/"]').length > 0
+              if (hasNavLinks) {
+                nextStepsSection.remove()
+              }
+            }
+          }
+        })
+      }
+
+      removeTextContent(clone)
+
+      // Process links to include URLs
+      const processLinks = (element: HTMLElement) => {
+        const links = element.querySelectorAll('a[href]')
+        links.forEach(link => {
+          const href = link.getAttribute('href')
+          const text = link.textContent || ''
+          
+          if (href && !text.includes(href)) {
+            // Add URL to link text if it's not already there
+            link.textContent = `${text} (${href})`
+          }
+        })
+      }
+
+      processLinks(clone)
+
+      // Remove any remaining navigation-like elements
+      const removeNavigationElements = (element: HTMLElement) => {
+        // Remove elements that look like navigation
+        const navLikeSelectors = [
+          'div:has(a[href*="/"])', // divs containing internal links
+          'section:has(a[href*="/"])', // sections containing internal links
+          'ul:has(a[href*="/"])', // lists containing internal links
+          'ol:has(a[href*="/"])' // ordered lists containing internal links
+        ]
+
+        // Remove elements with navigation-like classes
+        const navClasses = [
+          'nav',
+          'navigation', 
+          'sidebar',
+          'toc',
+          'breadcrumb',
+          'footer',
+          'pagination',
+          'prev',
+          'next',
+          'back',
+          'forward'
+        ]
+
+        navClasses.forEach(className => {
+          element.querySelectorAll(`.${className}, [class*="${className}"]`).forEach(el => {
+            el.remove()
+          })
+        })
+
+        // Remove elements containing only links (likely navigation)
+        const linkOnlyElements = element.querySelectorAll('div, section, ul, ol')
+        linkOnlyElements.forEach(el => {
+          const children = Array.from(el.children)
+          const allChildrenAreLinks = children.length > 0 && children.every(child => 
+            child.tagName === 'A' || child.querySelector('a')
+          )
+          
+          if (allChildrenAreLinks) {
+            el.remove()
+          }
+        })
+      }
+
+      removeNavigationElements(clone)
+
+      // Get the HTML content
+      const htmlContent = clone.innerHTML.trim()
+      
+      // Create both HTML and plain text versions
+      const htmlBlob = new Blob([htmlContent], { type: 'text/html' })
+      const plainText = clone.innerText || clone.textContent || ''
+      
+      // Try to copy as HTML (for rich text paste) and plain text fallback
+      try {
+        await navigator.clipboard.write([
+          new ClipboardItem({
+            'text/html': htmlBlob,
+            'text/plain': new Blob([plainText], { type: 'text/plain' })
+          })
+        ])
+      } catch {
+        // Fallback to plain text only
+        await navigator.clipboard.writeText(plainText)
+      }
+      
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch (error) {
+      console.error('Failed to copy:', error)
+    }
+  }
+
+  if (isMobile) return null
+
+  return (
+    <button
+      onClick={copyPageContent}
+      style={{
+        position: 'absolute',
+        top: `${buttonPosition.top}px`,
+        left: `${buttonPosition.left}px`,
+        zIndex: 1,
+        opacity: isVisible ? 1 : 0,
+        transition: 'opacity 0.3s ease-in-out'
+      }}
+      className={`
+        bg-gray-700 dark:bg-gray-800
+        border border-gray-500 dark:border-gray-600
+        shadow-sm
+        px-2 py-1 rounded
+        flex items-center gap-1
+        text-xs font-medium
+        ${copied ? 'text-green-400' : 'text-gray-200'}
+      `}
+      title="Copy article content"
+    >
+      {copied ? (
+        <>
+          <svg className="w-3 h-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+          </svg>
+          Copied!
+        </>
+      ) : (
+        <>
+          <svg className="w-3 h-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+          </svg>
+          Copy Text
+        </>
+      )}
+    </button>
+  )
+}

--- a/components/CopyPageButton.tsx
+++ b/components/CopyPageButton.tsx
@@ -149,8 +149,13 @@ export function CopyPageButton() {
               const href = el.getAttribute('href')
               const text = el.textContent || ''
               if (href) {
-                const absoluteUrl = makeAbsoluteUrl(href)
-                result += `[${text}](${absoluteUrl})`
+                // Skip anchor links (those starting with #)
+                if (href.startsWith('#')) {
+                  result += text
+                } else {
+                  const absoluteUrl = makeAbsoluteUrl(href)
+                  result += `[${text}](${absoluteUrl})`
+                }
               } else {
                 result += text
               }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,13 +1,17 @@
 import type { AppProps } from 'next/app'
 import { Inter } from 'next/font/google'
+import { CopyPageButton } from '../components/CopyPageButton'
 import '../styles/globals.css'
 
 const inter = Inter({ subsets: ['latin'] })
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <main className={inter.className}>
-      <Component {...pageProps} />
-    </main>
+    <>
+      <main className={inter.className}>
+        <Component {...pageProps} />
+      </main>
+      <CopyPageButton />
+    </>
   )
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -5,4 +5,13 @@
 /* Global image styling */
 img {
   border-radius: 5px;
+}
+
+/* Limit first h1 width on desktop */
+@media (min-width: 768px) {
+  main article h1:first-of-type,
+  main .nextra-content h1:first-of-type,
+  article h1:first-of-type {
+    max-width: 90%;
+  }
 } 

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -23,7 +23,7 @@ const config: DocsThemeConfig = {
 
   docsRepositoryBase: 'https://github.com/runreveal/runreveal-docs/blob/main',
   footer: {
-    content: 'RunReveal docs',
+    component: () => null,
   },
 }
 


### PR DESCRIPTION
# Add Copy Text Button for AI Tools

Added a **Copy Text** button to all documentation pages that extracts clean article content and converts it to Markdown format for pasting into AI tools like ChatGPT/Claude.

<img width="1493" height="426" alt="copytext-button" src="https://github.com/user-attachments/assets/14c20d58-a226-4381-af85-38f748c4dfa9" />
---

## What

- **Desktop:** Button positioned to the right of the first `h1` title  
- **Mobile:** Fixed icon at bottom-left corner with transparency  
- **Function:** Copies article content as Markdown format, excluding navigation/sidebars  
- **Smart filtering:** Removes navigation elements, buttons, and other breadcrumb text from the copied content
- **Link enhancement:** Converts relative links to absolute URLs for better AI context  

---

## How It Works

- **Component:** `components/CopyPageButton.tsx` – Pure React component  
- **Integration:** Added to `pages/_app.tsx` to appear on all pages  
- **Positioning:** Uses `getBoundingClientRect()` for precise positioning relative to `h1`  
- **Content extraction:** DOM `TreeWalker` that converts HTML → Markdown  
- **Markdown conversion:** Handles headings, paragraphs, code blocks, tables, lists  
- **Responsive:** `768px` breakpoint for mobile/desktop behavior  

---

## Files Changed

- `components/CopyPageButton.tsx` – New component  
- `pages/_app.tsx` – Added component import and usage  
- `styles/globals.css` – Added `h1` max-width (90%) for button space  

---

## Technical Details

- **Markdown output:** Uses `navigator.clipboard.writeText()` with Markdown formatting  
- **TreeWalker:** Efficiently traverses DOM to extract content  
- **Formatting:** Converts headings (`# ## ###`), code blocks (```` ``` ````), tables (`| | |`), lists (`-` / `1.`)  
- **No DOM manipulation:** Pure positioning, doesn't inject into page structure  
- **Performance:** Efficient with proper event listener cleanup  

---

## Example Output

```markdown
# AI Chat (Native & MCP)

Welcome to the RunReveal AI Chat section...

[Native AI Chat](https://docs.runreveal.com/ai-chat/native-ai-chat)  
[Model Context Protocol](https://docs.runreveal.com/ai-chat/model-context-protocol)

## Getting Started

Choose the option that best fits your workflow:

