### PR TITLE
Update ingestion setup docs for AWS S3 and Cloudflare sources

### DIFF
--- a/pages/notifications/getting-started.mdx
+++ b/pages/notifications/getting-started.mdx
@@ -20,7 +20,7 @@ In this guide, you'll learn how to:
 - Test your notifications  
 - View alert history
 - Add notifications to detection rules:
-  - **Managed Detections** - Out-of-the-box detections with default detection rules enabled. These are read-only and must be cloned first to add notifications.
+  - **Managed Detections** - Out-of-the-box detections with default detection rules enabled. You can now add notification channels directly by clicking edit and choosing a channel from the dropdown.
   - **Custom Detections** - Detections that you create or cloned detections.
   - **Sigma Streaming Detections** - Add notification channels to your sigma streaming in YAML syntax.
   - **Detection as Code** - Notifications for detection as code rules are not managed through the UI. See [Detection as Code](/detections/detection-as-code) for information on managing notifications in your detection code.
@@ -81,26 +81,27 @@ When detection rules trigger alerts in RunReveal, they automatically send notifi
     
     ![Managed Detections Overview](/notifications-getting-started-managed-detections.png)
     
-    <Callout type="warning">
-      Managed detections are read-only. You must clone them before adding notifications. This applies to both managed SQL detections and managed sigma detections.
+    <Callout type="info">
+      You can now add notification channels directly to managed detections without cloning them first.
     </Callout>
 
-    1. **Clone the Detection**
+    1. **Edit the Managed Detection**
        1. Go to **Detections** → **Detection Queries**
-       2. Find the managed detection you want to customize
-       3. Click **Clone & Edit** to create a copy of the detection
+       2. Find the managed detection you want to add notifications to
+       3. Click **Edit** to modify the detection
 
     2. **Add Notification Channels**
-       1. In the cloned detection, scroll to **Notification Channels** section
+       1. In the detection editor, scroll to **Notification Channels** section
        2. Click to view a dropdown of available channels
-       3. Select your newly created notification channel
+       3. Select your desired notification channel(s)
 
-    3. **Save and Deploy**
+    3. **Save Changes**
        1. Click **Save Detection** to store your changes
-       2. The detection will now send notifications to your channel when alerts are triggered
+       2. The managed detection will now send notifications to your selected channel(s) when alerts are triggered
 
-    4. **Deactivate Original Detection**
-       1. Toggle the "Active" switch to **off** on the original managed detection to avoid duplicate alerts
+    <Callout type="info">
+      Managed detections can now be edited directly to add or remove notification channels without needing to clone them first.
+    </Callout>
   </Tabs.Tab>
 
   <Tabs.Tab>

--- a/pages/sources/source-types/aws/s3-access.mdx
+++ b/pages/sources/source-types/aws/s3-access.mdx
@@ -1,4 +1,4 @@
-import { Callout } from 'nextra/components'
+import { Callout, Tabs } from 'nextra/components'
 
 # AWS S3 Access Logs
 
@@ -11,19 +11,21 @@ and troubleshooting access issues.
 
 Setup the ingestion of this source using one of the following guides.
 
-- [AWS S3 Bucket](/sources/object-storage/s3)
-- [AWS S3 Bucket with Custom SQS](/sources/object-storage/external-s3)
+<Tabs items={['AWS S3 Bucket', 'AWS S3 Bucket w/ Custom SQS']} defaultIndex="0">
 
-<Callout type='info'>
-If using an AWS S3 bucket use the following SNS topic ARN to send your bucket notifications.
+<Tabs.Tab>
+
+### AWS S3 Bucket
+
+Use the following SNS topic ARN to send your bucket notifications:
+
 ```
 arn:aws:sns:<REGION>:253602268883:runreveal_s3access
 ```
-</Callout>
 
-## Setup
+For detailed setup instructions, see the [AWS S3 Bucket](/sources/object-storage/s3) guide.
 
-### Step 1: Create a Target S3 Bucket for Access Logs
+#### Step 1: Create a Target S3 Bucket for Access Logs
 
 1. Sign in to the AWS Management Console and open the Amazon S3 console.
 2. Click on "Create bucket".
@@ -31,7 +33,7 @@ arn:aws:sns:<REGION>:253602268883:runreveal_s3access
 4. Configure the bucket settings as needed (e.g., versioning, encryption).
 5. Click "Create bucket" to finish.
 
-### Step 2: Configure Bucket Policy for Log Delivery
+#### Step 2: Configure Bucket Policy for Log Delivery
 
 1. In the S3 console, select the bucket you just created for access logs.
 2. Go to the "Permissions" tab.
@@ -62,7 +64,7 @@ arn:aws:sns:<REGION>:253602268883:runreveal_s3access
 5. Replace `{source-bucket-account-id}` with your AWS account ID.
 6. Click "Save changes".
 
-### Step 3: Enable Access Logging for Your Source S3 Bucket
+#### Step 3: Enable Access Logging for Your Source S3 Bucket
 
 1. In the S3 console, select the source bucket for which you want to enable access logging.
 2. Go to the "Properties" tab.
@@ -72,14 +74,107 @@ arn:aws:sns:<REGION>:253602268883:runreveal_s3access
 6. Optionally, specify a prefix for the log files (e.g., `logs/`).
 7. Click "Save changes".
 
-### Step 4: Verify Log Delivery
+#### Step 4: Configure SNS Event Notifications
+
+1. In the S3 console, select your target bucket (where access logs are being delivered).
+2. Go to the "Properties" tab.
+3. Scroll down to the "Event notifications" section and click "Create event notification".
+4. Configure the event notification:
+   - **Event name**: Enter a descriptive name (e.g., "S3AccessLogsToRunReveal")
+   - **Event types**: Select "All object create events"
+   - **Destination**: Choose "SNS topic"
+   - **SNS topic**: Select "Specify SNS topic ARN" and enter: `arn:aws:sns:<REGION>:253602268883:runreveal_s3access`
+5. Click "Save changes".
+
+#### Step 5: Verify Log Delivery
 
 1. Wait for a few minutes to allow some access requests to your source bucket.
 2. Go back to the S3 console and open your target bucket.
 3. Navigate to the folder where you specified the prefix (or the root if no prefix was specified).
 4. You should see log files appearing in this location with names like `YYYY-MM-DD-HH-MM-SS-XXXXXXXXXX`.
 
-### Step 5: Understanding S3 Access Log Format
+</Tabs.Tab>
+
+<Tabs.Tab>
+
+### AWS S3 Bucket w/ Custom SQS
+
+For detailed setup instructions, see the [AWS S3 Bucket with Custom SQS](/sources/object-storage/external-s3) guide.
+
+#### Step 1: Create a Target S3 Bucket for Access Logs
+
+1. Sign in to the AWS Management Console and open the Amazon S3 console.
+2. Click on "Create bucket".
+3. Enter a unique name for your bucket (e.g., `my-s3-access-logs`) and select the region.
+4. Configure the bucket settings as needed (e.g., versioning, encryption).
+5. Click "Create bucket" to finish.
+
+#### Step 2: Configure Bucket Policy for Log Delivery
+
+1. In the S3 console, select the bucket you just created for access logs.
+2. Go to the "Permissions" tab.
+3. Under "Bucket policy", click "Edit".
+4. Paste the following policy, replacing `{target-bucket-name}` with your actual bucket name:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "logging.s3.amazonaws.com"
+            },
+            "Action": "s3:PutObject",
+            "Resource": "arn:aws:s3:::{target-bucket-name}/*",
+            "Condition": {
+                "StringEquals": {
+                    "aws:SourceAccount": "{source-bucket-account-id}"
+                }
+            }
+        }
+    ]
+}
+```
+
+5. Replace `{source-bucket-account-id}` with your AWS account ID.
+6. Click "Save changes".
+
+#### Step 3: Enable Access Logging for Your Source S3 Bucket
+
+1. In the S3 console, select the source bucket for which you want to enable access logging.
+2. Go to the "Properties" tab.
+3. Scroll down to the "Server access logging" section and click "Edit".
+4. Check the box next to "Enable server access logging".
+5. Select the target bucket you created earlier from the "Target bucket" dropdown.
+6. Optionally, specify a prefix for the log files (e.g., `logs/`).
+7. Click "Save changes".
+
+#### Step 4: Configure SQS Queue Notifications
+
+1. Create an SQS queue following the [external S3 guide](/sources/object-storage/external-s3).
+2. In the S3 console, select your target bucket (where access logs are being delivered).
+3. Go to the "Properties" tab.
+4. Scroll down to the "Event notifications" section and click "Create event notification".
+5. Configure the event notification:
+   - **Event name**: Enter a descriptive name (e.g., "S3AccessLogsToSQS")
+   - **Event types**: Select "All object create events"
+   - **Destination**: Choose "SQS queue"
+   - **SQS queue**: Select your created SQS queue ARN
+6. Click "Save changes".
+
+#### Step 5: Verify Log Delivery
+
+1. Wait for a few minutes to allow some access requests to your source bucket.
+2. Go back to the S3 console and open your target bucket.
+3. Navigate to the folder where you specified the prefix (or the root if no prefix was specified).
+4. You should see log files appearing in this location with names like `YYYY-MM-DD-HH-MM-SS-XXXXXXXXXX`.
+
+</Tabs.Tab>
+
+</Tabs>
+
+## Understanding S3 Access Log Format
 
 S3 access logs contain the following fields in space-delimited format:
 

--- a/pages/sources/source-types/cloudflare/audit.mdx
+++ b/pages/sources/source-types/cloudflare/audit.mdx
@@ -2,17 +2,32 @@
 description: Quickly ingest your Cloudflare Audit logs
 ---
 
+import { Callout } from 'nextra/components'
+
+
 # Cloudflare Audit Logs
 
 Cloudflare Audit logs allow you to view audit events from your Cloudflare account. Audit logs give insights into what resources were changed in your Cloudflare organization.
 
 Cloudflare Audit logs will grab 30 days worth of logs for your account and backfill your source. After the initial load, RunReveal will attempt to poll the Cloudflare API to download your new audit logs every 60 seconds.
 
-## Ingest Method
 
-Currently, Cloudflare audit logs only support polling the Cloudflare API for new events every minute.
+## Ingest Methods
 
-## Setup
+Setup the ingestion of this source using one of the following guides.
+- API Polling
+- [AWS S3 Bucket](/sources/object-storage/s3)
+- [AWS S3 Bucket with Custom SQS](/sources/object-storage/external-s3)
+- [Azure Blob Storage](/sources/object-storage/azure)
+- [Google Cloud Storage](/sources/object-storage/gcs)
+
+<Callout type='info'>
+If using an AWS S3 bucket use the following SNS topic ARN to send your bucket notifications.
+```
+arn:aws:sns:<REGION>:253602268883:runreveal_cf_audit
+```
+</Callout>
+## API Polling Setup
 
 The two fields we require from your Cloudflare account are your account identifier and an API token.
 

--- a/pages/sources/source-types/cloudflare/gateway-network.mdx
+++ b/pages/sources/source-types/cloudflare/gateway-network.mdx
@@ -1,9 +1,30 @@
+import { Callout } from 'nextra/components'
+
 # Cloudflare Gateway Network Logs
 
 Cloudflare Gateway Network logs provide detailed information about network traffic and security events processed through Cloudflare's Zero Trust Gateway. These logs capture data about user connections, application access, network policies, and security threats detected by Cloudflare's network security services.
 
-## Coming Soon
+## Ingest Methods
 
-Documentation for Cloudflare Gateway Network logs is currently being developed.
+Setup the ingestion of this source using one of the following guides.
 
-Please check back soon for complete documentation.
+- [AWS S3 Bucket](/sources/object-storage/s3)
+- [AWS S3 Bucket with Custom SQS](/sources/object-storage/external-s3)
+- [Azure Blob Storage](/sources/object-storage/azure)
+- [Google Cloud Storage](/sources/object-storage/gcs)
+- [Cloudflare R2 Bucket](/sources/object-storage/r2)
+
+<Callout type='info'>
+If using an AWS S3 bucket use the following SNS topic ARN to send your bucket notifications.
+```
+arn:aws:sns:<REGION>:253602268883:runreveal_cf_gateway_network
+```
+</Callout>
+
+## Setup
+
+Setting up Cloudflare Gateway Network logs requires the use of Cloudflare Logpush.
+
+Navigate to the Logpush setup page in your Cloudflare account and create a new logpush job that sends your access request logs to your storage bucket.
+
+Once created Cloudflare will begin to push logs to your bucket and RunReveal will start to ingest them.

--- a/pages/sources/source-types/cloudflare/http.mdx
+++ b/pages/sources/source-types/cloudflare/http.mdx
@@ -12,6 +12,7 @@ Setup the ingestion of this source using one of the following guides.
 - [AWS S3 Bucket with Custom SQS](/sources/object-storage/external-s3)
 - [Azure Blob Storage](/sources/object-storage/azure)
 - [Google Cloud Storage](/sources/object-storage/gcs)
+- [Cloudflare R2 Bucket](/sources/object-storage/r2)
 
 <Callout type='info'>
 If using an AWS S3 bucket use the following SNS topic ARN to send your bucket notifications.

--- a/pages/sources/source-types/cloudflare/zt-access.mdx
+++ b/pages/sources/source-types/cloudflare/zt-access.mdx
@@ -1,9 +1,30 @@
+import { Callout } from 'nextra/components'
+
 # Cloudflare Access Requests
 
 Cloudflare Access Requests logs capture authentication and authorization events from Cloudflare Zero Trust Access. These logs provide visibility into user login attempts, application access patterns, and policy enforcement decisions across your organization's applications and resources.
 
-## Coming Soon
+## Ingest Methods
 
-Documentation for Cloudflare Access Requests is currently being developed.
+Setup the ingestion of this source using one of the following guides.
 
-Please check back soon for complete documentation.
+- [AWS S3 Bucket](/sources/object-storage/s3)
+- [AWS S3 Bucket with Custom SQS](/sources/object-storage/external-s3)
+- [Azure Blob Storage](/sources/object-storage/azure)
+- [Google Cloud Storage](/sources/object-storage/gcs)
+- [Cloudflare R2 Bucket](/sources/object-storage/r2)
+
+<Callout type='info'>
+If using an AWS S3 bucket use the following SNS topic ARN to send your bucket notifications.
+```
+arn:aws:sns:<REGION>:253602268883:runreveal_cf_access_requests
+```
+</Callout>
+
+## Setup
+
+Setting up Cloudflare Access Request logs requires the use of Cloudflare Logpush.
+
+Navigate to the Logpush setup page in your Cloudflare account and create a new logpush job that sends your access request logs to your storage bucket.
+
+Once created Cloudflare will begin to push logs to your bucket and RunReveal will start to ingest them.


### PR DESCRIPTION
Expanded and clarified setup instructions for AWS S3 Access logs, including step-by-step guides and tabbed instructions for different ingestion methods. Updated Cloudflare source documentation (audit, gateway-network, http, zt-access) to add detailed ingest method options, SNS topic ARNs, and setup guidance for Logpush and storage integrations. Also updated notifications getting started guide to reflect that managed detections can now have notification channels added directly without cloning.