### PR TITLE
Docs update redirects - fix typo and remove extra redirect 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,51 +10,11 @@ You can start developing with this command.
 npm run dev
 ```
 
-## Redrirects add in next.config.mjs as like this:
+## Add Redirects in next.config.mjs like this:
      {
         source: '/reference/native-ai-chat',
         destination: '/ai-chat/native-ai-chat',
         permanent: true,
       },
 
-### Full Example
-import nextra from 'nextra'
-import withYAML from 'next-yaml'
 
-const withNextra = nextra({
-  theme: 'nextra-theme-docs',
-  themeConfig: './theme.config.tsx',
-})
-
-export default withYAML(withNextra({
-  // Configure for Cloudflare Pages compatibility
-  output: 'export',
-  images: {
-    unoptimized: true,
-  },
-  // Add redirects here instead of using _redirects file
-  async redirects() {
-    return [
-      {
-        source: '/reference/native-ai-chat',
-        destination: '/ai-chat/native-ai-chat',
-        permanent: true,
-      },
-      {
-        source: '/reference/model-context-protocol',
-        destination: '/ai-chat/model-context-protocol',
-        permanent: true,
-      },
-      {
-        source: '/reference/custom-prompts',
-        destination: '/ai-chat/custom-prompts',
-        permanent: true,
-      },
-      {
-        source: '/references/native-ai-chat',
-        destination: '/ai-chat/native-ai-chat',
-        permanent: true,
-      },
-    ]
-  },
-}))

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -30,11 +30,6 @@ export default withYAML(withNextra({
         destination: '/ai-chat/custom-prompts',
         permanent: true,
       },
-      {
-        source: '/references/native-ai-chat',
-        destination: '/ai-chat/native-ai-chat',
-        permanent: true,
-      },
     ]
   },
 }))


### PR DESCRIPTION
Remove extra references redirect (not needed) and fixing a typo in README.md file